### PR TITLE
Add windows compatibility and support type, media and crossorigin attributes

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -26,10 +26,12 @@ const generateHeaderFile = (context, resources) => {
   const headersFile = `${generateDir}/_headers`;
   let content = '/*\n';
   resources.forEach(resource => {
-    const files = glob.sync(`${generateDir}/${resource.path}`);
+    const files = glob.sync(`${resource.path}`);
     files.forEach(file => {
       const url = file.replace(generateDir, '');
-      content += `  Link: <${url}>; rel=preload; as=${resource.as}\n`;
+      content += `  Link: <${url}>; rel=preload; as=${resource.as}`;
+      if(resource.crossorigin) content += ' crossorigin';
+      content += '\n';
     });
   });
   fs.appendFile(headersFile, content, err => {

--- a/lib/module.js
+++ b/lib/module.js
@@ -28,7 +28,7 @@ const generateHeaderFile = (context, resources) => {
   resources.forEach(resource => {
     const files = glob.sync(`${resource.path}`);
     files.forEach(file => {
-      const url = file.replace(generateDir, '');
+      const url = file.replace(generateDir.replace(/\\/g, '/'), '');
       content += `  Link: <${url}>; rel=preload; as=${resource.as}`;
       if(resource.crossorigin) content += ` crossorigin=${resource.crossorigin}`;
       if(resource.type) content += ` type=${resource.type}`;

--- a/lib/module.js
+++ b/lib/module.js
@@ -30,7 +30,9 @@ const generateHeaderFile = (context, resources) => {
     files.forEach(file => {
       const url = file.replace(generateDir, '');
       content += `  Link: <${url}>; rel=preload; as=${resource.as}`;
-      if(resource.crossorigin) content += ' crossorigin';
+      if(resource.crossorigin) content += ` crossorigin=${resource.crossorigin}`;
+      if(resource.type) content += ` type=${resource.type}`;
+      if(resource.media) content += ` media=${resource.media}`;
       content += '\n';
     });
   });


### PR DESCRIPTION
According to [Netlify post](https://www.netlify.com/blog/2017/07/18/http/2-server-push-on-netlify/), link path should be relative of root folder and Fonts [should have](https://stackoverflow.com/questions/46401942/http2-pushed-webfonts-not-used) `crossorigin` tag.