### PR TITLE
CSP Errors - disable header on file other than html

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -38,7 +38,7 @@ const generateHeaderFile = (context, resources) => {
     });
   });
 
-  const files = glob.sync(`${generateDir}/**/!(*.html|*.htm)`);
+  const files = glob.sync(`${generateDir}/**/*.*`,{ ignore: `${generateDir}/**/*.htm?`, nodir: true});
   files.forEach(file => {
     const url = file.replace(generateDir.replace(/\\/g, '/'), '');
     content += `${url}`;

--- a/lib/module.js
+++ b/lib/module.js
@@ -37,6 +37,16 @@ const generateHeaderFile = (context, resources) => {
       content += '\n';
     });
   });
+
+  const files = glob.sync(`${generateDir}/**/!(*.html|*.htm)`);
+  files.forEach(file => {
+    const url = file.replace(generateDir.replace(/\\/g, '/'), '');
+    content += `${url}`;
+    content += '\n';
+    content += `  Link: ''`;
+    content += '\n';
+  });
+
   fs.appendFile(headersFile, content, err => {
     if (err) {
       logger.error(err);

--- a/lib/module.js
+++ b/lib/module.js
@@ -43,7 +43,7 @@ const generateHeaderFile = (context, resources) => {
     const url = file.replace(generateDir.replace(/\\/g, '/'), '');
     content += `${url}`;
     content += '\n';
-    content += `  Link: ''`;
+    content += `  Link: <>`;
     content += '\n';
   });
 


### PR DESCRIPTION
As described by #6 and in documentation https://www.netlify.com/docs/headers-and-basic-auth/#multi-key-header-rules
I override by special glob header of other files. This work because Netlify will collapse two same header using last one.
This solution produce less line - it will be one array for all files and list with 1 item to all static files. 
Second solution that will work is to add all static links to all html templates but it will be double of size so I choose first one.

There is space to optimization as using more "*" or having option to enable / disable this fix.